### PR TITLE
Support where in aggregate functions

### DIFF
--- a/lib/weaviate/query.rb
+++ b/lib/weaviate/query.rb
@@ -48,6 +48,7 @@ module Weaviate
     def aggs(
       class_name:,
       fields: nil,
+      where: nil,
       object_limit: nil,
       near_text: nil,
       near_vector: nil,
@@ -59,6 +60,7 @@ module Weaviate
         aggs_query(
           class_name: class_name,
           fields: fields,
+          where: where,
           near_text: near_text,
           near_vector: near_vector,
           near_image: near_image,
@@ -183,6 +185,7 @@ module Weaviate
     def aggs_query(
       class_name:,
       fields:,
+      where: nil,
       near_text: nil,
       near_vector: nil,
       near_image: nil,
@@ -200,7 +203,8 @@ module Weaviate
               #{near_text.present? ? "nearText: #{near_text}" : ""},
               #{near_vector.present? ? "nearVector: #{near_vector}" : ""},
               #{near_image.present? ? "nearImage: #{near_image}" : ""},
-              #{near_object.present? ? "nearObject: #{near_object}" : ""}
+              #{near_object.present? ? "nearObject: #{near_object}" : ""},
+              #{where.present? ? "where: #{where}" : ""}
             ) {
               #{fields}
             }


### PR DESCRIPTION
 ``` {"data"=>
    {"Aggregate"=>
      {"FileResource"=>
        [{"groupedBy"=>{"path"=>["r_id"], "value"=>"5"}, "meta"=>{"count"=>245}},
         {"groupedBy"=>{"path"=>["r_id"], "value"=>"2"}, "meta"=>{"count"=>189}},
         {"groupedBy"=>{"path"=>["r_id"], "value"=>"9"}, "meta"=>{"count"=>150}},
         {"groupedBy"=>{"path"=>["r_id"], "value"=>"7"}, "meta"=>{"count"=>10}},
         {"groupedBy"=>{"path"=>["r_id"], "value"=>"6"}, "meta"=>{"count"=>9}},
         {"groupedBy"=>{"path"=>["r_id"], "value"=>"8"}, "meta"=>{"count"=>5}},
         {"groupedBy"=>{"path"=>["r_id"], "value"=>"4"}, "meta"=>{"count"=>2}}]}}}>
```
`where_clause = vs.convert_to_weaviate_format({ r_id: { ContainsAny: [5] } })`

```
irb(main):230:1* vs.client.graphql.execute(
irb(main):231:2*       aggs_query( vs.client,
irb(main):232:2*         class_name: FileResource.to_s,
irb(main):233:2*         fields: 'meta { count } groupedBy { path value }',
irb(main):234:2*         where: where_clause
irb(main):235:1*       ),
irb(main):236:1*       group_by: ["r_id"],
irb(main):237:1*       object_limit: nil
irb(main):238:0> )
```
```
{"data"=>{"Aggregate"=>{"FileResource"=>[{"groupedBy"=>{"path"=>["r_id"], "value"=>"5"}, "meta"=>{"count"=>245}}]}}}>
```