### PR TITLE
Update objects.rb to pass tenant to batch_delete as param

### DIFF
--- a/lib/weaviate/objects.rb
+++ b/lib/weaviate/objects.rb
@@ -169,8 +169,6 @@ module Weaviate
 
       unless consistency_level.nil?
         validate_consistency_level!(consistency_level)
-
-        path << "?consistency_level=#{consistency_level.to_s.upcase}"
       end
 
       response = client.connection.delete(path) do |req|
@@ -182,6 +180,7 @@ module Weaviate
         }
         req.body["output"] = output unless output.nil?
         req.body["dryRun"] = dry_run unless dry_run.nil?
+        req.params["consistency_level"] = consistency_level.to_s.upcase unless consistency_level.nil?
         req.params["tenant"] = tenant unless tenant.nil?
       end
 

--- a/lib/weaviate/objects.rb
+++ b/lib/weaviate/objects.rb
@@ -162,7 +162,8 @@ module Weaviate
       where:,
       consistency_level: nil,
       output: nil,
-      dry_run: nil
+      dry_run: nil,
+      tenant: nil
     )
       path = "batch/#{PATH}"
 
@@ -181,6 +182,7 @@ module Weaviate
         }
         req.body["output"] = output unless output.nil?
         req.body["dryRun"] = dry_run unless dry_run.nil?
+        req.params["tenant"] = tenant unless tenant.nil?
       end
 
       response.body


### PR DESCRIPTION
Turns out, with multi-tenancy, `batch_delete` also needs to pass along the tenant _as a request param_. This patch works for me, but I'm not sure how this will affect the final query if `consistency_level` is being used. Thoughts?